### PR TITLE
tidyr::separate - não está mais gerando um warning

### DIFF
--- a/R/read_tjmg.R
+++ b/R/read_tjmg.R
@@ -27,7 +27,10 @@ read_tjmg <- function() {
     dplyr::filter(!stringr::str_detect(value, "Tel")) |>
     tidyr::separate(col = value,
                     sep = "\\.{2,}",
-                    into = c("codigo_munic", "distancias")) |>
+                    into = c("codigo_munic", "distancias"),
+                    fill = "right",
+                    extra = "drop"
+                      ) |>
     dplyr::mutate(dplyr::across(dplyr::everything(), stringr::str_squish),
                   distrito = dplyr::if_else(stringr::str_detect(codigo_munic, "\\d$|-$"), "SIM", "NÃO"),
                   distrito_de = dplyr::case_when(is.na(distancias) & dplyr::lag(distrito) == "NÃO" ~ dplyr::lag(codigo_munic))) |>


### PR DESCRIPTION
O que estava gerando o warning é um tidyr::separate. Essa função por padrão emite warnings quando ela preenche com NA ou quando tem mais elementos do que o necessário. Alterei os argumentos para que use as configurações padrão porém sem warning.


closes #1 